### PR TITLE
[ html ] Highlight lines based on URL hash component

### DIFF
--- a/src/Katla/HTML.idr
+++ b/src/Katla/HTML.idr
@@ -111,6 +111,9 @@ standalonePre config = """
         let start = document.getElementById(m[1])
         let end = document.getElementById(m[2])
         if (start) {
+          if (end && end.compareDocumentPosition(start) === 4) {
+            ([start,end] = [end,start])
+          }
           start.scrollIntoView()
           let parent = start.parentElement
           let lines = parent.children

--- a/src/Katla/HTML.idr
+++ b/src/Katla/HTML.idr
@@ -99,9 +99,30 @@ standalonePre config = """
     .IdrisLineNumber:target {
       color: gray;
     }
+    .IdrisHighlight {
+      background-color: yellow;
+    }
     </style>
+    <script>
+    function handleHash() {
+      if (!location.hash) return
+      let m = location.hash.match(/#(line\\d+)(?:-(line\\d+))?/)
+      if (m) {
+        let [_, start, end] = m
+        let el = document.getElementById(start)
+        if (el) {
+          el.scrollIntoView()
+          for (; el; el.nextElementSibling) {
+            el.className += ' IdrisHighlight'
+            if (!end || el.id == end) break
+            el = el.nextElementSibling
+          }
+        }
+      }
+    }
+    </script>
   </head>
-  <body>
+  <body onload="handleHash()">
   <code>
   """
 
@@ -144,8 +165,8 @@ mkDriver config = MkDriver
     let ln = show ln
         lineID = "line\{ln}"
         desc = concat (replicate (minus wdth (length ln)) "&nbsp;" ++ [ln]) in
-    ##"<a href="#\##{lineID}" id="\##{lineID}" class="IdrisLineNumber"> \##{desc} | </a>"##
-  , "<br />")
+    ##"<div id="\##{lineID}"><a href="#\##{lineID}" class="IdrisLineNumber"> \##{desc} | </a>"##
+  , "</div>")
   (escapeHTML config)
   annotate
   (standalonePre config, standalonePost)

--- a/src/Katla/HTML.idr
+++ b/src/Katla/HTML.idr
@@ -108,18 +108,23 @@ standalonePre config = """
       if (!location.hash) return
       let m = location.hash.match(/#(line\\d+)(?:-(line\\d+))?/)
       if (m) {
-        let [_, start, end] = m
-        let el = document.getElementById(start)
-        if (el) {
-          el.scrollIntoView()
-          for (; el; el.nextElementSibling) {
-            el.className += ' IdrisHighlight'
-            if (!end || el.id == end) break
-            el = el.nextElementSibling
+        let start = document.getElementById(m[1])
+        let end = document.getElementById(m[2])
+        if (start) {
+          start.scrollIntoView()
+          let parent = start.parentElement
+          let lines = parent.children
+          let className = ''
+          for (let n = 0; n < lines.length; n++) {
+            let el = lines[n]
+            if (el === start) className = 'IdrisHighlight'
+            el.className = className
+            if (el === end || className && !end) className = ''
           }
         }
       }
     }
+    window.addEventListener('hashchange',handleHash)
     </script>
   </head>
   <body onload="handleHash()">

--- a/tests/examples/standalone/expected
+++ b/tests/examples/standalone/expected
@@ -92,3 +92,41 @@
 \end{Verbatim}
 \end{document}
 Expected: directly writing to file gives the same results
+"IdrisLineNumber"> 25 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span><br />
+< <a href="#line26" id="line26" class="IdrisLineNumber"> 26 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;<span class="IdrisPostulate">believe_me</span>&nbsp;<span class="IdrisData">%MkWorld</span><br />
+< <a href="#line27" id="line27" class="IdrisLineNumber"> 27 | </a><br />
+< <a href="#line28" id="line28" class="IdrisLineNumber"> 28 | </a><span class="IdrisFunction">Rainbow</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">Type</span><br />
+< <a href="#line29" id="line29" class="IdrisLineNumber"> 29 | </a><span class="IdrisFunction">Rainbow</span>&nbsp;<span class="IdrisBound">n</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;&nbsp;<span class="IdrisType">[</span>&nbsp;<span class="IdrisBound">n</span>&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisFunction">m</span>&nbsp;<span class="IdrisType">,</span>&nbsp;<span class="IdrisBound">n</span>&nbsp;<span class="IdrisData">]</span><br />
+< <a href="#line30" id="line30" class="IdrisLineNumber"> 30 | </a><br />
+---
+> <div id="line0"><a href="#line0" class="IdrisLineNumber"> &nbsp;0 | </a><span class="IdrisKeyword">namespace</span>&nbsp;<span class="IdrisNamespace">L0</span></div>
+> <div id="line1"><a href="#line1" class="IdrisLineNumber"> &nbsp;1 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">public</span>&nbsp;<span class="IdrisKeyword">export</span></div>
+> <div id="line2"><a href="#line2" class="IdrisLineNumber"> &nbsp;2 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">data</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Type</span></div>
+> <div id="line3"><a href="#line3" class="IdrisLineNumber"> &nbsp;3 | </a></div>
+> <div id="line4"><a href="#line4" class="IdrisLineNumber"> &nbsp;4 | </a></div>
+> <div id="line5"><a href="#line5" class="IdrisLineNumber"> &nbsp;5 | </a><span class="IdrisKeyword">namespace</span>&nbsp;<span class="IdrisNamespace">L1</span></div>
+> <div id="line6"><a href="#line6" class="IdrisLineNumber"> &nbsp;6 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">public</span>&nbsp;<span class="IdrisKeyword">export</span></div>
+> <div id="line7"><a href="#line7" class="IdrisLineNumber"> &nbsp;7 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">data</span>&nbsp;<span class="IdrisType">List1</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">where</span></div>
+> <div id="line8"><a href="#line8" class="IdrisLineNumber"> &nbsp;8 | </a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">Nil</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">List1</span></div>
+> <div id="line9"><a href="#line9" class="IdrisLineNumber"> &nbsp;9 | </a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">Cons1</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List1</span></div>
+> <div id="line10"><a href="#line10" class="IdrisLineNumber"> 10 | </a></div>
+> <div id="line11"><a href="#line11" class="IdrisLineNumber"> 11 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">public</span>&nbsp;<span class="IdrisKeyword">export</span></div>
+> <div id="line12"><a href="#line12" class="IdrisLineNumber"> 12 | </a>&nbsp;&nbsp;<span class="IdrisFunction">(::)</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List1</span></div>
+> <div id="line13"><a href="#line13" class="IdrisLineNumber"> 13 | </a>&nbsp;&nbsp;<span class="IdrisFunction">(::)</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;<span class="IdrisData">Cons1</span></div>
+> <div id="line14"><a href="#line14" class="IdrisLineNumber"> 14 | </a></div>
+> <div id="line15"><a href="#line15" class="IdrisLineNumber"> 15 | </a><span class="IdrisKeyword">namespace</span>&nbsp;<span class="IdrisNamespace">L2</span></div>
+> <div id="line16"><a href="#line16" class="IdrisLineNumber"> 16 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">public</span>&nbsp;<span class="IdrisKeyword">export</span></div>
+> <div id="line17"><a href="#line17" class="IdrisLineNumber"> 17 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">data</span>&nbsp;<span class="IdrisType">(::)</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">where</span></div>
+> <div id="line18"><a href="#line18" class="IdrisLineNumber"> 18 | </a></div>
+> <div id="line19"><a href="#line19" class="IdrisLineNumber"> 19 | </a><span class="IdrisKeyword">namespace</span>&nbsp;<span class="IdrisNamespace">L0</span></div>
+> <div id="line20"><a href="#line20" class="IdrisLineNumber"> 20 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">public</span>&nbsp;<span class="IdrisKeyword">export</span></div>
+> <div id="line21"><a href="#line21" class="IdrisLineNumber"> 21 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">data</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">where</span></div>
+> <div id="line22"><a href="#line22" class="IdrisLineNumber"> 22 | </a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">Nil</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">List0</span></div>
+> <div id="line23"><a href="#line23" class="IdrisLineNumber"> 23 | </a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">(::)</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span><span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List0</span></div>
+> <div id="line24"><a href="#line24" class="IdrisLineNumber"> 24 | </a></div>
+> <div id="line25"><a href="#line25" class="IdrisLineNumber"> 25 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span></div>
+> <div id="line26"><a href="#line26" class="IdrisLineNumber"> 26 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;<span class="IdrisPostulate">believe_me</span>&nbsp;<span class="IdrisData">%MkWorld</span></div>
+> <div id="line27"><a href="#line27" class="IdrisLineNumber"> 27 | </a></div>
+> <div id="line28"><a href="#line28" class="IdrisLineNumber"> 28 | </a><span class="IdrisFunction">Rainbow</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">Type</span></div>
+> <div id="line29"><a href="#line29" class="IdrisLineNumber"> 29 | </a><span class="IdrisFunction">Rainbow</span>&nbsp;<span class="IdrisBound">n</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;&nbsp;<span class="IdrisType">[</span>&nbsp;<span class="IdrisBound">n</span>&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisFunction">m</span>&nbsp;<span class="IdrisType">,</span>&nbsp;<span class="IdrisBound">n</span>&nbsp;<span class="IdrisData">]</span></div>
+> <div id="line30"><a href="#line30" class="IdrisLineNumber"> 30 | </a></div>

--- a/tests/examples/standalone/expected
+++ b/tests/examples/standalone/expected
@@ -92,7 +92,15 @@
 \end{Verbatim}
 \end{document}
 Expected: directly writing to file gives the same results
-"IdrisLineNumber"> 25 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span><br />
+ata</span>&nbsp;<span class="IdrisType">(::)</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">where</span><br />
+< <a href="#line18" id="line18" class="IdrisLineNumber"> 18 | </a><br />
+< <a href="#line19" id="line19" class="IdrisLineNumber"> 19 | </a>namespace&nbsp;<span class="IdrisNamespace">L0</span><br />
+< <a href="#line20" id="line20" class="IdrisLineNumber"> 20 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">public</span>&nbsp;<span class="IdrisKeyword">export</span><br />
+< <a href="#line21" id="line21" class="IdrisLineNumber"> 21 | </a>&nbsp;&nbsp;<span class="IdrisKeyword">data</span>&nbsp;<span class="IdrisType">List0</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">where</span><br />
+< <a href="#line22" id="line22" class="IdrisLineNumber"> 22 | </a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">Nil</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">List0</span><br />
+< <a href="#line23" id="line23" class="IdrisLineNumber"> 23 | </a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">(::)</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span><span class="IdrisType">Type</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">List0</span><br />
+< <a href="#line24" id="line24" class="IdrisLineNumber"> 24 | </a><br />
+< <a href="#line25" id="line25" class="IdrisLineNumber"> 25 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span><br />
 < <a href="#line26" id="line26" class="IdrisLineNumber"> 26 | </a><span class="IdrisFunction">m</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;<span class="IdrisPostulate">believe_me</span>&nbsp;<span class="IdrisData">%MkWorld</span><br />
 < <a href="#line27" id="line27" class="IdrisLineNumber"> 27 | </a><br />
 < <a href="#line28" id="line28" class="IdrisLineNumber"> 28 | </a><span class="IdrisFunction">Rainbow</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">Nat</span>&nbsp;<span class="IdrisKeyword">-&gt;</span>&nbsp;<span class="IdrisType">Type</span><br />


### PR DESCRIPTION
This is a first pass at javascript for highlighting lines and ranges of lines from the 'hash' part of the URL. It handles both `line123` and `line123-line127`.  I added a `scrollIntoView` call because browser won't find the anchor in the hyphenated case. 

It was necessary to replace the `<br>` line breaks with `<div>` and lift the line ids to the div, so we would have an element to highlight.

The highlight color is `yellow`. Let me know if you want to make it a configuration parameter. I wasn't sure because it doesn't apply to the LaTeX case.