### PR TITLE
Escape $ in markdown html output

### DIFF
--- a/src/Katla/Markdown.idr
+++ b/src/Katla/Markdown.idr
@@ -15,6 +15,7 @@ escapeMarkdown : Config -> Char -> List Char
 escapeMarkdown config ' ' = unpack config.space
 escapeMarkdown config '_' = unpack "\\_"
 escapeMarkdown config '*' = unpack "\\*"
+escapeMarkdown config '$' = unpack "\\$"
 escapeMarkdown config c = unpack (htmlEscape $ cast c)
 
 export

--- a/src/Katla/Markdown.idr
+++ b/src/Katla/Markdown.idr
@@ -16,6 +16,7 @@ escapeMarkdown config ' ' = unpack config.space
 escapeMarkdown config '_' = unpack "\\_"
 escapeMarkdown config '*' = unpack "\\*"
 escapeMarkdown config '$' = unpack "\\$"
+escapeMarkdown config '\\' = unpack "\\\\"
 escapeMarkdown config c = unpack (htmlEscape $ cast c)
 
 export

--- a/src/Katla/Markdown.idr
+++ b/src/Katla/Markdown.idr
@@ -15,7 +15,7 @@ escapeMarkdown : Config -> Char -> List Char
 escapeMarkdown config ' ' = unpack config.space
 escapeMarkdown config '_' = unpack "\\_"
 escapeMarkdown config '*' = unpack "\\*"
-escapeMarkdown config '$' = unpack "\\$"
+escapeMarkdown config '$' = unpack "&#36;"
 escapeMarkdown config '\\' = unpack "\\\\"
 escapeMarkdown config c = unpack (htmlEscape $ cast c)
 

--- a/tests/examples/markdown/Source.md
+++ b/tests/examples/markdown/Source.md
@@ -41,6 +41,7 @@ And here is a successful definition (which demonstrates that we have indeed impo
 ```idris
 main : IO ()
 main = putStrLn
+     $ (\x => x)
      $ unwords
      [ "Hello,"
      , "from"

--- a/tests/examples/markdown/source-expected.md
+++ b/tests/examples/markdown/source-expected.md
@@ -75,7 +75,8 @@ And here is a successful definition (which demonstrates that we have indeed impo
 <code class="IdrisCode">
 <span class="IdrisFunction">main</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">IO</span>&nbsp;<span class="IdrisType">()</span><br />
 <span class="IdrisFunction">main</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;<span class="IdrisFunction">putStrLn</span><br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$&nbsp;<span class="IdrisFunction">unwords</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\$&nbsp;<span class="IdrisKeyword">(\\</span><span class="IdrisBound">x</span>&nbsp;<span class="IdrisKeyword">=&gt;</span>&nbsp;<span class="IdrisBound">x</span><span class="IdrisKeyword">)</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\$&nbsp;<span class="IdrisFunction">unwords</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">[</span>&nbsp;<span class="IdrisData">&quot;Hello,&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;from&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;the&quot;</span><br />

--- a/tests/examples/markdown/source-expected.md
+++ b/tests/examples/markdown/source-expected.md
@@ -75,8 +75,8 @@ And here is a successful definition (which demonstrates that we have indeed impo
 <code class="IdrisCode">
 <span class="IdrisFunction">main</span>&nbsp;<span class="IdrisKeyword">:</span>&nbsp;<span class="IdrisType">IO</span>&nbsp;<span class="IdrisType">()</span><br />
 <span class="IdrisFunction">main</span>&nbsp;<span class="IdrisKeyword">=</span>&nbsp;<span class="IdrisFunction">putStrLn</span><br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\$&nbsp;<span class="IdrisKeyword">(\\</span><span class="IdrisBound">x</span>&nbsp;<span class="IdrisKeyword">=&gt;</span>&nbsp;<span class="IdrisBound">x</span><span class="IdrisKeyword">)</span><br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\$&nbsp;<span class="IdrisFunction">unwords</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#36;&nbsp;<span class="IdrisKeyword">(\\</span><span class="IdrisBound">x</span>&nbsp;<span class="IdrisKeyword">=&gt;</span>&nbsp;<span class="IdrisBound">x</span><span class="IdrisKeyword">)</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#36;&nbsp;<span class="IdrisFunction">unwords</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">[</span>&nbsp;<span class="IdrisData">&quot;Hello,&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;from&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;the&quot;</span><br />

--- a/tests/examples/standalone/Rainbow.idr
+++ b/tests/examples/standalone/Rainbow.idr
@@ -27,4 +27,4 @@ m : Nat
 m = believe_me %MkWorld
 
 Rainbow : Nat -> Type
-Rainbow n =  [ n , m , n ]
+Rainbow n = (\x => x) $ [ n , m , n ]

--- a/tests/examples/standalone/expected
+++ b/tests/examples/standalone/expected
@@ -87,7 +87,7 @@
 \IdrisFunction{m}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisPostulate{believe_me}\KatlaSpace{}\IdrisData{\%MkWorld}
 
 \IdrisFunction{Rainbow}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Nat}\KatlaSpace{}\IdrisKeyword{->}\KatlaSpace{}\IdrisType{Type}
-\IdrisFunction{Rainbow}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\KatlaSpace{}\IdrisType{[}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisData{,}\KatlaSpace{}\IdrisFunction{m}\KatlaSpace{}\IdrisType{,}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisData{]}
+\IdrisFunction{Rainbow}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisKeyword{(\textbackslash{}}\IdrisBound{x}\KatlaSpace{}\IdrisKeyword{=>}\KatlaSpace{}\IdrisBound{x}\IdrisKeyword{)}\KatlaSpace{}$\KatlaSpace{}\IdrisType{[}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisData{,}\KatlaSpace{}\IdrisFunction{m}\KatlaSpace{}\IdrisType{,}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisData{]}
 
 \end{Verbatim}
 \end{document}


### PR DESCRIPTION
Pandoc is failing to process @ohad 's setoid paper because `$` is not being escaped in markdown html output.  This patch adds `$` to the list of characters being escaped in markdown html.
