### PR TITLE
[ fix ] escape backticks in markdown mode

### DIFF
--- a/src/Katla/Markdown.idr
+++ b/src/Katla/Markdown.idr
@@ -17,6 +17,7 @@ escapeMarkdown config '_' = unpack "\\_"
 escapeMarkdown config '*' = unpack "\\*"
 escapeMarkdown config '$' = unpack "&#36;"
 escapeMarkdown config '\\' = unpack "\\\\"
+escapeMarkdown config '`' = unpack "&#96;"
 escapeMarkdown config c = unpack (htmlEscape $ cast c)
 
 export

--- a/tests/examples/markdown/Source.md
+++ b/tests/examples/markdown/Source.md
@@ -48,5 +48,6 @@ main = putStrLn
      , "the"
      , "Markdown"
      , "mode"
+     , "escaped backticks" `const` ""
      ]
 ```

--- a/tests/examples/markdown/source-expected.md
+++ b/tests/examples/markdown/source-expected.md
@@ -82,6 +82,7 @@ And here is a successful definition (which demonstrates that we have indeed impo
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;the&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;Markdown&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;mode&quot;</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">,</span>&nbsp;<span class="IdrisData">&quot;escaped&nbsp;backticks&quot;</span>&nbsp;<span class="IdrisFunction">&#96;const&#96;</span>&nbsp;<span class="IdrisData">&quot;&quot;</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="IdrisData">]</span><br />
 </code>
 


### PR DESCRIPTION
Reported by @ohad on the discord