### PR TITLE
Ignore hidden

### DIFF
--- a/src/Katla/Engine.idr
+++ b/src/Katla/Engine.idr
@@ -244,7 +244,7 @@ engineWithRange input output lineNumberWidth meta driver rowRange currentDecor c
 export
 codeTeX : LiterateStyle
 codeTeX = MkLitStyle
-              [("\\begin{code}", "\\end{code}")]
+              [(#"\begin{code}"#, #"\end{code}"#)]
               Nil
               [".tex", ".ltx"]
 export

--- a/src/Katla/Engine.idr
+++ b/src/Katla/Engine.idr
@@ -242,6 +242,12 @@ engineWithRange input output lineNumberWidth meta driver rowRange currentDecor c
         engineWithRange input output lineNumberWidth meta driver rowRange nextDecor nextPos
 
 export
+codeTeX : LiterateStyle
+codeTeX = MkLitStyle
+              [("\\begin{code}", "\\end{code}")]
+              Nil
+              [".tex", ".ltx"]
+export
 engine : Backend
        -> Config
        -> (input, output : File)
@@ -262,7 +268,7 @@ engine Literate cfg input output lnw meta driver pos
   = do Right content <- fRead input
          | Left err => do putStrLn "Error: \{show err}"
                           exitFailure
-       let Right ts = lexLiterate styleTeX content
+       let Right ts = lexLiterate codeTeX content
          | Left err => do putStrLn "Error: \{show err}"
                           exitFailure
        initSty cfg

--- a/src/Katla/LaTeX.idr
+++ b/src/Katla/LaTeX.idr
@@ -29,126 +29,126 @@ annotate (Just dec) s = apply (convert dec) s
   where
 
     apply : String -> String -> String
-    apply f a = "\\\{f}{\{a}}"
+    apply f a = #"\\#{f}{\#{a}}"#
 
 export
 laTeXHeader : Config -> String
-laTeXHeader cfg =  """
-\\usepackage{fancyvrb}
-\\usepackage[x11names]{xcolor}
-\\newcommand{\\Katla}                [2][]{\\VerbatimInput[commandchars=\\\\\\{\\}#1]{#2}}
-\\newcommand{\\KatlaNewline}            {}
-\\newcommand{\\KatlaSpace}              {\{cfg.space}}
-\\newcommand{\\KatlaDash}               {\\string-}
-\\newcommand{\\KatlaUnderscore}         {\\string_}
-\\newcommand{\\KatlaTilde}              {\\string~}
-\\newcommand{\\IdrisHlightFont}         {\{cfg.font}}
-\\newcommand{\\IdrisHlightStyleData}    {\{cfg.datacons .style}}
-\\newcommand{\\IdrisHlightStyleType}    {\{cfg.typecons .style}}
-\\newcommand{\\IdrisHlightStyleBound}   {\{cfg.bound    .style}}
-\\newcommand{\\IdrisHlightStyleFunction}{\{cfg.function .style}}
-\\newcommand{\\IdrisHlightStyleKeyword} {\{cfg.keyword  .style}}
-\\newcommand{\\IdrisHlightStyleImplicit}{\{cfg.bound    .style}}
-\\newcommand{\\IdrisHlightStyleComment} {\{cfg.comment  .style}}
-\\newcommand{\\IdrisHlightStyleHole}    {\{cfg.hole     .style}}
-\\newcommand{\\IdrisHlightStyleNamespace}{\{cfg.namespce.style}}
-\\newcommand{\\IdrisHlightStylePostulate}{\{cfg.postulte.style}}
-\\newcommand{\\IdrisHlightStyleModule}   {\{cfg.aModule .style}}
+laTeXHeader cfg =  #"""
+\usepackage{fancyvrb}
+\usepackage[x11names]{xcolor}
+\newcommand{\Katla}                [2][]{\VerbatimInput[commandchars=\\\{\}#1]{#2}}
+\newcommand{\KatlaNewline}            {}
+\newcommand{\KatlaSpace}              {\#{cfg.space}}
+\newcommand{\KatlaDash}               {\string-}
+\newcommand{\KatlaUnderscore}         {\string_}
+\newcommand{\KatlaTilde}              {\string~}
+\newcommand{\IdrisHlightFont}         {\#{cfg.font}}
+\newcommand{\IdrisHlightStyleData}    {\#{cfg.datacons .style}}
+\newcommand{\IdrisHlightStyleType}    {\#{cfg.typecons .style}}
+\newcommand{\IdrisHlightStyleBound}   {\#{cfg.bound    .style}}
+\newcommand{\IdrisHlightStyleFunction}{\#{cfg.function .style}}
+\newcommand{\IdrisHlightStyleKeyword} {\#{cfg.keyword  .style}}
+\newcommand{\IdrisHlightStyleImplicit}{\#{cfg.bound    .style}}
+\newcommand{\IdrisHlightStyleComment} {\#{cfg.comment  .style}}
+\newcommand{\IdrisHlightStyleHole}    {\#{cfg.hole     .style}}
+\newcommand{\IdrisHlightStyleNamespace}{\{cfg.namespce.style}}
+\newcommand{\IdrisHlightStylePostulate}{\{cfg.postulte.style}}
+\newcommand{\IdrisHlightStyleModule}   {\{cfg.aModule .style}}
 
-\\newcommand{\\IdrisHlightColourData}    {\{cfg.datacons .colour}}
-\\newcommand{\\IdrisHlightColourType}    {\{cfg.typecons .colour}}
-\\newcommand{\\IdrisHlightColourBound}   {\{cfg.bound    .colour}}
-\\newcommand{\\IdrisHlightColourFunction}{\{cfg.function .colour}}
-\\newcommand{\\IdrisHlightColourKeyword} {\{cfg.keyword  .colour}}
-\\newcommand{\\IdrisHlightColourImplicit}{\{cfg.bound    .colour}}
-\\newcommand{\\IdrisHlightColourComment} {\{cfg.comment  .colour}}
-\\newcommand{\\IdrisHlightColourHole}    {\{cfg.hole     .colour}}
-\\newcommand{\\IdrisHlightColourNamespace}{\{cfg.namespce.colour}}
-\\newcommand{\\IdrisHlightColourPostulate}{\{cfg.postulte.colour}}
-\\newcommand{\\IdrisHlightColourModule}   {\{cfg.aModule .colour}}
+\newcommand{\IdrisHlightColourData}    {\#{cfg.datacons .colour}}
+\newcommand{\IdrisHlightColourType}    {\#{cfg.typecons .colour}}
+\newcommand{\IdrisHlightColourBound}   {\#{cfg.bound    .colour}}
+\newcommand{\IdrisHlightColourFunction}{\#{cfg.function .colour}}
+\newcommand{\IdrisHlightColourKeyword} {\#{cfg.keyword  .colour}}
+\newcommand{\IdrisHlightColourImplicit}{\#{cfg.bound    .colour}}
+\newcommand{\IdrisHlightColourComment} {\#{cfg.comment  .colour}}
+\newcommand{\IdrisHlightColourHole}    {\#{cfg.hole     .colour}}
+\newcommand{\IdrisHlightColourNamespace}{\#{cfg.namespce.colour}}
+\newcommand{\IdrisHlightColourPostulate}{\#{cfg.postulte.colour}}
+\newcommand{\IdrisHlightColourModule}   {\#{cfg.aModule .colour}}
 
-\\newcommand{\\IdrisHole}[1]{{%
-    \\colorbox{\\IdrisHlightColourHole}{%
-      \\IdrisHlightStyleHole\\IdrisHlightFont%
+\newcommand{\IdrisHole}[1]{{%
+    \colorbox{\IdrisHlightColourHole}{%
+      \IdrisHlightStyleHole\IdrisHlightFont%
       #1}}}
 
-\\newcommand{\\RawIdrisHighlight}[3]{{\\textcolor{#1}{\\IdrisHlightFont#2{#3}}}}
+\newcommand{\RawIdrisHighlight}[3]{{\textcolor{#1}{\IdrisHlightFont#2{#3}}}}
 
-\\newcommand{\\IdrisData}[1]{\\RawIdrisHighlight{\\IdrisHlightColourData}{\\IdrisHlightStyleData}{#1}}
-\\newcommand{\\IdrisType}[1]{\\RawIdrisHighlight{\\IdrisHlightColourType}{\\IdrisHlightStyleType}{#1}}
-\\newcommand{\\IdrisBound}[1]{\\RawIdrisHighlight{\\IdrisHlightColourBound}{\\IdrisHlightStyleBound}{#1}}
-\\newcommand{\\IdrisFunction}[1]{\\RawIdrisHighlight{\\IdrisHlightColourFunction}{\\IdrisHlightStyleFunction}{#1}}
-\\newcommand{\\IdrisKeyword}[1]{\\RawIdrisHighlight{\\IdrisHlightColourKeyword}{\\IdrisHlightStyleKeyword}{#1}}
-\\newcommand{\\IdrisImplicit}[1]{\\RawIdrisHighlight{\\IdrisHlightColourImplicit}{\\IdrisHlightStyleImplicit}{#1}}
-\\newcommand{\\IdrisComment}[1]{\\RawIdrisHighlight{\\IdrisHlightColourComment}{\\IdrisHlightStyleComment}{#1}}
-\\newcommand{\\IdrisNamespace}[1]{\\RawIdrisHighlight{\\IdrisHlightColourNamespace}{\\IdrisHlightStyleNamespace}{#1}}
-\\newcommand{\\IdrisPostulate}[1]{\\RawIdrisHighlight{\\IdrisHlightColourPostulate}{\\IdrisHlightStylePostulate}{#1}}
-\\newcommand{\\IdrisModule}[1]{\\RawIdrisHighlight{\\IdrisHlightColourModule}{\\IdrisHlightStyleModule}{#1}}
+\newcommand{\IdrisData}[1]{\RawIdrisHighlight{\IdrisHlightColourData}{\IdrisHlightStyleData}{#1}}
+\newcommand{\IdrisType}[1]{\RawIdrisHighlight{\IdrisHlightColourType}{\IdrisHlightStyleType}{#1}}
+\newcommand{\IdrisBound}[1]{\RawIdrisHighlight{\IdrisHlightColourBound}{\IdrisHlightStyleBound}{#1}}
+\newcommand{\IdrisFunction}[1]{\RawIdrisHighlight{\IdrisHlightColourFunction}{\IdrisHlightStyleFunction}{#1}}
+\newcommand{\IdrisKeyword}[1]{\RawIdrisHighlight{\IdrisHlightColourKeyword}{\IdrisHlightStyleKeyword}{#1}}
+\newcommand{\IdrisImplicit}[1]{\RawIdrisHighlight{\IdrisHlightColourImplicit}{\IdrisHlightStyleImplicit}{#1}}
+\newcommand{\IdrisComment}[1]{\RawIdrisHighlight{\IdrisHlightColourComment}{\IdrisHlightStyleComment}{#1}}
+\newcommand{\IdrisNamespace}[1]{\RawIdrisHighlight{\IdrisHlightColourNamespace}{\IdrisHlightStyleNamespace}{#1}}
+\newcommand{\IdrisPostulate}[1]{\RawIdrisHighlight{\IdrisHlightColourPostulate}{\IdrisHlightStylePostulate}{#1}}
+\newcommand{\IdrisModule}[1]{\RawIdrisHighlight{\IdrisHlightColourModule}{\IdrisHlightStyleModule}{#1}}
 
-\\DefineVerbatimEnvironment%
-{code}{Verbatim}{commandchars=\\\\\\{\\}}
+\DefineVerbatimEnvironment%
+{code}{Verbatim}{commandchars=\\\{\}}
 
-\\usepackage{comment}
-\\excludecomment{hidden}
+\usepackage{comment}
+\excludecomment{hidden}
 
 % Bugfix in fancyvrb to allow inline saved listings
-\\makeatletter
-\\let\\FV@ProcessLine\\relax
-\\makeatother
+\makeatletter
+\let\FV@ProcessLine\relax
+\makeatother
 
-"""
+"""#
 
 
 export
 standalonePre : Config -> String
-standalonePre config = """
-  \\documentclass{article}
+standalonePre config = #"""
+  \documentclass{article}
 
-  \\usepackage{inconsolata}
+  \usepackage{inconsolata}
 
-  \{laTeXHeader config}
+  \#{laTeXHeader config}
 
-  \\begin{document}
-  \\begin{Verbatim}[commandchars=\\\\\\{\\}]
-  """
+  \begin{document}
+  \begin{Verbatim}[commandchars=\\\{\}]
+  """#
 
 export
 standalonePost : String
-standalonePost = """
-  \\end{Verbatim}
-  \\end{document}
-  """
+standalonePost = #"""
+  \end{Verbatim}
+  \end{document}
+  """#
 
 export
 makeMacroPre : String -> String
-makeMacroPre name = """
-  \\newcommand\\\{name}[1][]{\\UseVerbatim[#1]{\{name}}}
-  \\begin{SaveVerbatim}[commandchars=\\\\\\{\\}]{\{name}}
-  """
+makeMacroPre name = #"""
+  \newcommand\\#{name}[1][]{\UseVerbatim[#1]{\#{name}}}
+  \begin{SaveVerbatim}[commandchars=\\\{\}]{\#{name}}
+  """#
 
 export
 makeMacroPost : String
-makeMacroPost = """
-  \\end{SaveVerbatim}
-  """
+makeMacroPost = #"""
+  \end{SaveVerbatim}
+  """#
 
 export
 makeInlineMacroPre : String -> String
-makeInlineMacroPre name = """
-  \\newcommand\\\{name}[1][]{\\UseVerb[#1]{\{name}}}
-  \\begin{SaveVerbatim}[commandchars=\\\\\\{\\}]{\{name}}
-  """
+makeInlineMacroPre name = #"""
+  \newcommand\\#{name}[1][]{\UseVerb[#1]{\#{name}}}
+  \begin{SaveVerbatim}[commandchars=\\\{\}]{\#{name}}
+  """#
 
 export
 makeInlineMacroPost : String
-makeInlineMacroPost = """
-  \\end{SaveVerbatim}
-  """
+makeInlineMacroPost = #"""
+  \end{SaveVerbatim}
+  """#
 
 export
 mkDriver : Config -> Driver
 mkDriver config = MkDriver
-  (\_, _ => "", "\\KatlaNewline{}")
+  (\_, _ => "", #"\KatlaNewline{}"#)
   escapeLatex
   annotate
   (standalonePre config, standalonePost)

--- a/src/Katla/LaTeX.idr
+++ b/src/Katla/LaTeX.idr
@@ -88,6 +88,9 @@ laTeXHeader cfg =  """
 \\DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\\\\{\\}}
 
+\\usepackage{comment}
+\\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \\makeatletter
 \\let\\FV@ProcessLine\\relax

--- a/src/Katla/Literate.idr
+++ b/src/Katla/Literate.idr
@@ -18,20 +18,20 @@ initStyFile = do
 
 export
 makeMacroPre : String -> String
-makeMacroPre name = """
-  \\begin{code}
-  """
+makeMacroPre name = #"""
+  \begin{code}
+  """#
 
 export
 makeMacroPost : String
-makeMacroPost = """
-  \\end{code}
-  """
+makeMacroPost = #"""
+  \end{code}
+  """#
 
 export
 mkDriver : Config -> Driver
 mkDriver config = MkDriver
-  (\ wdth, ln => "", "\\KatlaNewline{}")
+  (\ wdth, ln => "", #"\KatlaNewline{}"#)
   (escapeLatex)
   annotate
   ("", "")

--- a/tests/examples/config/expected
+++ b/tests/examples/config/expected
@@ -52,6 +52,9 @@
 \DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\{\}}
 
+\usepackage{comment}
+\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \makeatletter
 \let\FV@ProcessLine\relax

--- a/tests/examples/init/expected
+++ b/tests/examples/init/expected
@@ -75,6 +75,9 @@
 \DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\{\}}
 
+\usepackage{comment}
+\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \makeatletter
 \let\FV@ProcessLine\relax

--- a/tests/examples/literate/Source.tex
+++ b/tests/examples/literate/Source.tex
@@ -18,6 +18,11 @@ main : IO ()
 main = putStrLn "Hello from inside TeX"
 \end{code}
 
+\begin{hidden}
+succ : Nat -> Nat
+succ = S
+\end{hidden}
+
 We're hoping the output pdf will have the \textbf{code blocks} highlighted
 while the rest is typeset by \LaTeX{}.
 

--- a/tests/examples/literate/idris2-expected.sty
+++ b/tests/examples/literate/idris2-expected.sty
@@ -53,6 +53,9 @@
 \DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\{\}}
 
+\usepackage{comment}
+\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \makeatletter
 \let\FV@ProcessLine\relax

--- a/tests/examples/literate/source-expected.tex
+++ b/tests/examples/literate/source-expected.tex
@@ -19,6 +19,11 @@ This code is embedded in a literate file.
 \IdrisFunction{main}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisFunction{putStrLn}\KatlaSpace{}\IdrisData{"Hello\KatlaSpace{}from\KatlaSpace{}inside\KatlaSpace{}TeX"}\KatlaNewline{}
 \end{code}
 
+\begin{hidden}
+succ : Nat -> Nat
+succ = S
+\end{hidden}
+
 We're hoping the output pdf will have the \textbf{code blocks} highlighted
 while the rest is typeset by \LaTeX{}.
 

--- a/tests/examples/macros/expected
+++ b/tests/examples/macros/expected
@@ -53,6 +53,9 @@
 \DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\{\}}
 
+\usepackage{comment}
+\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \makeatletter
 \let\FV@ProcessLine\relax

--- a/tests/examples/preamble/expected
+++ b/tests/examples/preamble/expected
@@ -52,6 +52,9 @@
 \DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\{\}}
 
+\usepackage{comment}
+\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \makeatletter
 \let\FV@ProcessLine\relax

--- a/tests/examples/standalone/expected
+++ b/tests/examples/standalone/expected
@@ -57,6 +57,9 @@
 \DefineVerbatimEnvironment%
 {code}{Verbatim}{commandchars=\\\{\}}
 
+\usepackage{comment}
+\excludecomment{hidden}
+
 % Bugfix in fancyvrb to allow inline saved listings
 \makeatletter
 \let\FV@ProcessLine\relax


### PR DESCRIPTION
I changed the lexer so that it would leave alone `hidden` blocks. I added the `comment` package to ignore them.

I also noticed a lot of the latex template string had a lot of escaped strings, I made use of raw strings to make it easier to maintain those templates.

For some reason I couldn't run the tests locally so I'm trusting CI on that one