### PR TITLE
Fix cli parsing

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -24,7 +24,7 @@ on:
 ########################################################################
 
 env:
-  IDRIS2_COMMIT: 24ac56de8809ae7a2cd0126f01110d4b762389fc
+  IDRIS2_COMMIT: 9e84b153bd3d7d5a63ec9e6a9adfa47a067ea172
   COLLIE_COMMIT: ed2eda5e04fbd02a7728e915d396e14cc7ec298e
   IDRALL_COMMIT: 62a455894b1db5134c8b56d31aadb31d483a4b2c
   SCHEME: scheme

--- a/src/Katla/CLI.idr
+++ b/src/Katla/CLI.idr
@@ -8,6 +8,7 @@ import Katla.HTML
 import Katla.Engine
 
 %default covering
+%hide Collie.Modifiers.infix.(::=)
 
 failWithUsage : {nm : _} -> Command nm -> IO ()
 failWithUsage cmd

--- a/src/Katla/Config.idr
+++ b/src/Katla/Config.idr
@@ -184,7 +184,10 @@ export
 getConfiguration : Backend -> (configFile : Maybe String) -> IO Config
 getConfiguration backend Nothing = pure $ defaultConfig backend
 getConfiguration backend (Just filename) = do
-  Right config <- liftIOEither (deriveFromDhallString {ty = Config} filename)
+  Right fileContent <- readFile filename
+  | Left err => putStrLn "Error reading file: \{show err}"
+             >> exitFailure
+  Right config <- liftIOEither (deriveFromDhallString {ty = Config} fileContent)
   | Left err => do putStrLn  """
                      Error while parsing configuration file \{filename}:
                      \{show err}

--- a/src/Katla/LaTeX.idr
+++ b/src/Katla/LaTeX.idr
@@ -7,6 +7,8 @@ import System.File
 import Collie
 import Katla.Config
 
+%hide Collie.Modifiers.infix.(::=)
+
 export
 escapeLatex : Char -> List Char
 escapeLatex '-' = fastUnpack "\\KatlaDash{}"

--- a/tests/examples/init/run
+++ b/tests/examples/init/run
@@ -2,7 +2,7 @@ rm -rf temp
 mkdir temp
 # Test Katla
 $1 latex init | tee temp/generated.dhall
-$1 latex preamble --config ./temp/generated.dhall | tee temp/katla-preamble.tex
+$1 latex preamble --config temp/generated.dhall | tee temp/katla-preamble.tex
 $1 latex preamble --config ./temp/generated.dhall temp/katla-preamble-direct.tex
 
 


### PR DESCRIPTION
The documentation reads

>     --config  Preamble configuration file in Dhall format.

However, writing `--config *config file*` would break with an obscure error message.

This is because the filename would be passed as argument directly to the Dhall parser, rather than being read from the filesystem and be given to the dhall parser.

The reason it worked until now is because if you write `./filepath`, dhall knows to interpret it as a file to read from the filesystem and will perform the file reading for us. If you write `filepath` the dhall parser will fail assuming that it is an unbound variable. This PR fixes this behaviour by reading the file before passing its content to the parser.

I also fixed some warnings due to conflicting fixity declarations.