### PR TITLE
Add usage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,41 @@ Dependencies:
 + [Idrall](https://github.com/alexhumphreys/idrall) library for
   [Dhall](https://dhall-lang.org/) bindings
 
+# Usage
+
+To generate a document, a corresponding `ttm` file is required along with the `idr` file.
+After a successful build, you will find them in `build/ttc/{ttc_version}`.
+`ttc_version` depends on your environment.
+
+To generate an HTML:
+
+```console
+$ katla html path/to/src/Foo.idr path/to/ttm/Foo.ttm > Foo.html
+```
+
+To generate a TeX file and a PDF:
+
+```console
+$ katla latex path/to/src/Foo.idr path/to/ttm/Foo.ttm > Foo.tex
+$ pdflatex Foo.tex
+```
+
+Generated TeX files may have dependencies.
+Currently, they require the following packages:
+
+- inconsolata
+- fancyvrb
+- xcolor
+
+You can investigate potential dependencies by searching the code:
+
+```console
+$ grep usepackage src/Katla/LaTeX.idr
+```
+
+Active examples of using Katla can be found in the main repository of Idris2:  
+https://github.com/idris-lang/Idris2/blob/main/.github/scripts/katla.sh
+
 # Demo
 See [example tests](./tests/examples).
 


### PR DESCRIPTION
I expanded the Readme document and added "Usage" section.

As a reference for active examples, I included a link to the CI code in the main repository.
But I am not sure if this is a good idea because once the CI code has changed, this link may cause confusion.
If it doesn't seem good, please drop the link.