### PR TITLE
Allow using Pandoc filter in LaTeX commands

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -24,9 +24,9 @@ on:
 ########################################################################
 
 env:
-  IDRIS2_COMMIT: 9e84b153bd3d7d5a63ec9e6a9adfa47a067ea172
+  IDRIS2_COMMIT: e4431891e915c6866a6eea18046dcb3bcdfa8d89
   COLLIE_COMMIT: ed2eda5e04fbd02a7728e915d396e14cc7ec298e
-  IDRALL_COMMIT: 62a455894b1db5134c8b56d31aadb31d483a4b2c
+  IDRALL_COMMIT: 86d84e44f7e2d07e597ca10b7d0a3451992b5605
   SCHEME: scheme
 
 ########################################################################
@@ -61,6 +61,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y chezscheme
           sudo apt-get install -y texlive texlive-fonts-extra
+          sudo apt-get install -y pandoc
 
       - name: Install Idris2 & its API
         if: steps.cache-idris2.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -24,9 +24,9 @@ on:
 ########################################################################
 
 env:
-  IDRIS2_COMMIT: 9e84b153bd3d7d5a63ec9e6a9adfa47a067ea172
+  IDRIS2_COMMIT: e4431891e915c6866a6eea18046dcb3bcdfa8d89
   COLLIE_COMMIT: ed2eda5e04fbd02a7728e915d396e14cc7ec298e
-  IDRALL_COMMIT: 62a455894b1db5134c8b56d31aadb31d483a4b2c
+  IDRALL_COMMIT: 86d84e44f7e2d07e597ca10b7d0a3451992b5605
   SCHEME: scheme
 
 ########################################################################
@@ -35,6 +35,10 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        pandoc: [ pandoc-no, pandoc-yes ]
+
     runs-on: ubuntu-latest
     steps:
 
@@ -61,6 +65,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y chezscheme
           sudo apt-get install -y texlive texlive-fonts-extra
+
+      - name: Install Pandoc
+        if: ${{ matrix.pandoc == 'pandoc-yes' }}
+        run: |
+          sudo apt-get install -y pandoc
 
       - name: Install Idris2 & its API
         if: steps.cache-idris2.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: project src install test doc clean
 
-project: build/exec/katla
+project: build/exec/katla build/exec/katla-pandoc
 
 src: src/**/*.idr
 
 build/exec/katla: src 
 	idris2 --build katla.ipkg
 
-build/exec/katla-pandoc: .PHONY
+build/exec/katla-pandoc:
 	idris2 --build katla-pandoc.ipkg
 
 install: build/exec/katla build/exec/katla-pandoc

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -1,11 +1,18 @@
 module Main
 
+import System
 import Test.Golden
 
 %default covering
 
-tests : TestPool
-tests = MkTestPool "Examples using Katla" [] Nothing
+Pandoc : Requirement
+Pandoc = MkReq "pandoc" $ do
+    (_, 0) <- run "command -v pandoc"
+        | _ => pure Nothing
+    pure $ Just "pandoc"
+
+baseTests : TestPool
+baseTests = MkTestPool "Examples using Katla" [] Nothing
   [ "standalone"
   , "raw-snippet"
   , "preamble"
@@ -14,12 +21,17 @@ tests = MkTestPool "Examples using Katla" [] Nothing
   , "init"
   , "markdown"
   , "literate"
-  , "pandoc"
+  ]
+
+pandocTests : TestPool
+pandocTests = MkTestPool "Examples using Katla-Pandoc" [Pandoc] Nothing
+  [ "pandoc"
   ]
 
 main : IO ()
 main = runner
-  [ withPath "examples" tests
+  [ withPath "examples" baseTests
+  , withPath "examples" pandocTests
   ]
 
  where

--- a/tests/examples/pandoc/Source.md
+++ b/tests/examples/pandoc/Source.md
@@ -24,6 +24,31 @@ x : Nat
 x = 1 + 2
 ```
 
+And here's a code block in a \LaTeX{} figure environment:
+
+```{=latex}
+\newcommand\myfig[2]{
+    \begin{figure}[h]
+    \centering
+    #2
+    \caption{#1}
+    \end{figure}
+}
+```
+
+```{=latex}
+\myfig{Definition of $y$}{
+```
+
+```idr
+y : Nat
+y = x + 3
+```
+
+```{=latex}
+}
+```
+
 We can use namespaces by adding the `namespace` attribute, such as to provide alternate definitions for functions. Consider this function signature:
 
 ```{.idr namespace="A"}

--- a/tests/examples/pandoc/run
+++ b/tests/examples/pandoc/run
@@ -1,8 +1,10 @@
+PATH="../../../build/exec:$PATH"
+
 rm -rf temp build
 
 mkdir temp
 
 # Test Katla pandoc
-pandoc ./Source.md --filter "$1-pandoc" -o temp/source.tex
+pandoc ./Source.md --filter "$1-pandoc" --to=latex | sed 's/KatlaSnippet[[:alpha:]]\+/KatlaSnippet/g' > temp/source.tex
 pandoc ./Source.md --filter "$1-pandoc" -o temp/source.pdf
 diff source-expected.tex temp/source.tex >> output

--- a/tests/examples/pandoc/source-expected.tex
+++ b/tests/examples/pandoc/source-expected.tex
@@ -15,132 +15,74 @@ anything in the output PDF.
 
 We can use all Idris 2 features. Here's an example code block:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{x}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Nat}\KatlaNewline{}
-\IdrisFunction{x}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisData{1}\KatlaSpace{}\IdrisFunction{+}\KatlaSpace{}\IdrisData{2}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}
+
+And here's a code block in a \LaTeX{} figure environment:
+
+\newcommand\myfig[2]{
+    \begin{figure}[h]
+    \centering
+    #2
+    \caption{#1}
+    \end{figure}
+}
+
+\myfig{Definition of $y$}{
+
+\KatlaSnippet{}
+
+}
 
 We can use namespaces by adding the \texttt{namespace} attribute, such
 as to provide alternate definitions for functions. Consider this
 function signature:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{f}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Vect}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisBound{a}\KatlaSpace{}\IdrisKeyword{\KatlaDash{}>}\KatlaSpace{}\IdrisType{Vect}\KatlaSpace{}\IdrisKeyword{(}\IdrisBound{n}\KatlaSpace{}\IdrisFunction{+}\KatlaSpace{}\IdrisBound{n}\IdrisKeyword{)}\KatlaSpace{}\IdrisBound{a}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}
 
-Here's one implementation for
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{f}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{}:
+Here's one implementation for \KatlaSnippet{}:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{f}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisFunction{++}\KatlaSpace{}\IdrisBound{xs}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}
 
 By repeating the signature in a different namespace, in a hidden code
 block, I can give an alternate definition:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{f}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisFunction{++}\KatlaSpace{}\IdrisFunction{reverse}\KatlaSpace{}\IdrisBound{xs}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}
 
 \hypertarget{inline-code}{%
 \section{Inline Code}\label{inline-code}}
 
 As well as block code, we can have inline code, like
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{the}\KatlaSpace{}\IdrisType{Nat}\KatlaSpace{}\IdrisData{3}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{}. Here's another:
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisData{1}\KatlaSpace{}\IdrisFunction{+}\KatlaSpace{}\IdrisData{2}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{}. We can also call the function we previously defined:
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{f}\KatlaSpace{}\IdrisData{[1,}\KatlaSpace{}\IdrisData{2,}\KatlaSpace{}\IdrisData{3]}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{}.
+\KatlaSnippet{}. Here's another: \KatlaSnippet{}. We can
+also call the function we previously defined: \KatlaSnippet{}.
 
 By default, a code block is interpreted as top-level Idris 2
 declarations, while inline code is interpreted as an expression. But we
 can switch it up if we wish.
 
 By using the \texttt{decls} class, we can write an inline declaration:
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{g}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Nat}\KatlaSpace{}\IdrisKeyword{\KatlaDash{}>}\KatlaSpace{}\IdrisType{Nat}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}.
 
 By using the \texttt{expr} class, we can write a block expression:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisData{[}\KatlaNewline{}
-\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\IdrisData{1,}\KatlaNewline{}
-\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\IdrisData{2,}\KatlaNewline{}
-\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\IdrisData{3}\KatlaNewline{}
-\IdrisData{]}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}
 
 \hypertarget{types}{%
 \section{Types}\label{types}}
 
 Sometimes, Idris 2 cannot infer the type of an expression. Is
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisData{[1,}\KatlaSpace{}\IdrisData{2,}\KatlaSpace{}\IdrisData{3]}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{} a
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisType{List}\KatlaSpace{}\IdrisType{Nat}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{}, or a
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisType{Vect}\KatlaSpace{}\IdrisData{3}\KatlaSpace{}\IdrisType{Integer}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{}? We can use the \texttt{type} attribute to tell Idris 2
-which one it should be.
+\KatlaSnippet{} a \KatlaSnippet{}, or a
+\KatlaSnippet{}? We can use the \texttt{type} attribute to tell
+Idris 2 which one it should be.
 
 \hypertarget{multiple-files}{%
 \section{Multiple Files}\label{multiple-files}}
 
 If you need an import to \emph{not} be available, namespaces are not
 enough. We can use the \texttt{file} attribute to put snippets in
-separate files. For example, the signature of
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisFunction{f}\KatlaNewline{}
-\end{SaveVerbatim}
-\KatlaSnippet{} fails to compile if we use a new file, that hasn't
-imported
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerb[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisType{Vect}\KatlaNewline{}
-\end{SaveVerbatim}
+separate files. For example, the signature of \KatlaSnippet{}
+fails to compile if we use a new file, that hasn't imported
 \KatlaSnippet{}.
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisKeyword{failing}\KatlaSpace{}\IdrisData{"Undefined\KatlaSpace{}name\KatlaSpace{}Vect."}\KatlaNewline{}
-\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\IdrisFunction{f}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}Vect\KatlaSpace{}n\KatlaSpace{}a\KatlaSpace{}\IdrisKeyword{\KatlaDash{}>}\KatlaSpace{}Vect\KatlaSpace{}\IdrisKeyword{(}n\KatlaSpace{}+\KatlaSpace{}n\IdrisKeyword{)}\KatlaSpace{}a\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}
 
 \hypertarget{packages}{%
@@ -150,11 +92,4 @@ We can add Idris 2 packages to the YAML metadata of the Markdown file,
 using the \texttt{idris2-packages} key. For example, adding
 \texttt{contrib} allows us to use the \texttt{Language.JSON} module.
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
-\begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
-\IdrisKeyword{import}\KatlaSpace{}\IdrisModule{Language.JSON}\KatlaNewline{}
-\KatlaNewline{}
-\IdrisFunction{x}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Maybe}\KatlaSpace{}\IdrisType{JSON}\KatlaNewline{}
-\IdrisFunction{x}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisFunction{parse}\KatlaSpace{}\IdrisData{\#"\{"x":\KatlaSpace{}1,\KatlaSpace{}"y":\KatlaSpace{}2\}"\#}\KatlaNewline{}
-\end{SaveVerbatim}
 \KatlaSnippet{}


### PR DESCRIPTION
Following conversation with @ohad, where he explained that you cannot use Verbatim environments inside LaTeX command calls.

I moved the Katla snippet declarations to the headers, so the only thing left in the document body is the command call, and added a test that the Pandoc plugin interacts well with commands. This does mean intermediate LaTeX looks a little strange without an explicit template, but it still works fine.

As a nice side-effect, this also gets rid of the extra spaces I complained about when I first made this plugin.