### PR TITLE
Use BUseVerbatim block verbatim environment for LaTeX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ src: src/**/*.idr
 build/exec/katla: src 
 	idris2 --build katla.ipkg
 
-build/exec/katla-pandoc: .PHONY
+build/exec/katla-pandoc:
 	idris2 --build katla-pandoc.ipkg
 
 install: build/exec/katla build/exec/katla-pandoc

--- a/src/Katla/LaTeX.idr
+++ b/src/Katla/LaTeX.idr
@@ -121,7 +121,7 @@ standalonePost = """
 export
 makeMacroPre : String -> String
 makeMacroPre name = """
-  \\newcommand\\\{name}[1][]{\\UseVerbatim[#1]{\{name}}}
+  \\newcommand\\\{name}[1][]{\\BUseVerbatim[#1]{\{name}}}
   \\begin{SaveVerbatim}[commandchars=\\\\\\{\\}]{\{name}}
   """
 

--- a/tests/examples/pandoc/source-expected.tex
+++ b/tests/examples/pandoc/source-expected.tex
@@ -15,7 +15,7 @@ anything in the output PDF.
 
 We can use all Idris 2 features. Here's an example code block:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisFunction{x}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Nat}\KatlaNewline{}
 \IdrisFunction{x}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisData{1}\KatlaSpace{}\IdrisFunction{+}\KatlaSpace{}\IdrisData{2}\KatlaNewline{}
@@ -26,7 +26,7 @@ We can use namespaces by adding the \texttt{namespace} attribute, such
 as to provide alternate definitions for functions. Consider this
 function signature:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisFunction{f}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}\IdrisType{Vect}\KatlaSpace{}\IdrisBound{n}\KatlaSpace{}\IdrisBound{a}\KatlaSpace{}\IdrisKeyword{\KatlaDash{}>}\KatlaSpace{}\IdrisType{Vect}\KatlaSpace{}\IdrisKeyword{(}\IdrisBound{n}\KatlaSpace{}\IdrisFunction{+}\KatlaSpace{}\IdrisBound{n}\IdrisKeyword{)}\KatlaSpace{}\IdrisBound{a}\KatlaNewline{}
 \end{SaveVerbatim}
@@ -39,7 +39,7 @@ Here's one implementation for
 \end{SaveVerbatim}
 \KatlaSnippet{}:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisFunction{f}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisFunction{++}\KatlaSpace{}\IdrisBound{xs}\KatlaNewline{}
 \end{SaveVerbatim}
@@ -48,7 +48,7 @@ Here's one implementation for
 By repeating the signature in a different namespace, in a hidden code
 block, I can give an alternate definition:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisFunction{f}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisKeyword{=}\KatlaSpace{}\IdrisBound{xs}\KatlaSpace{}\IdrisFunction{++}\KatlaSpace{}\IdrisFunction{reverse}\KatlaSpace{}\IdrisBound{xs}\KatlaNewline{}
 \end{SaveVerbatim}
@@ -87,7 +87,7 @@ By using the \texttt{decls} class, we can write an inline declaration:
 
 By using the \texttt{expr} class, we can write a block expression:
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisData{[}\KatlaNewline{}
 \KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\IdrisData{1,}\KatlaNewline{}
@@ -136,7 +136,7 @@ imported
 \end{SaveVerbatim}
 \KatlaSnippet{}.
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisKeyword{failing}\KatlaSpace{}\IdrisData{"Undefined\KatlaSpace{}name\KatlaSpace{}Vect."}\KatlaNewline{}
 \KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\KatlaSpace{}\IdrisFunction{f}\KatlaSpace{}\IdrisKeyword{:}\KatlaSpace{}Vect\KatlaSpace{}n\KatlaSpace{}a\KatlaSpace{}\IdrisKeyword{\KatlaDash{}>}\KatlaSpace{}Vect\KatlaSpace{}\IdrisKeyword{(}n\KatlaSpace{}+\KatlaSpace{}n\IdrisKeyword{)}\KatlaSpace{}a\KatlaNewline{}
@@ -150,7 +150,7 @@ We can add Idris 2 packages to the YAML metadata of the Markdown file,
 using the \texttt{idris2-packages} key. For example, adding
 \texttt{contrib} allows us to use the \texttt{Language.JSON} module.
 
-\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\UseVerbatim[#1]{KatlaSnippet}}
+\let\KatlaSnippet\relax{}\newcommand\KatlaSnippet[1][]{\BUseVerbatim[#1]{KatlaSnippet}}
 \begin{SaveVerbatim}[commandchars=\\\{\}]{KatlaSnippet}
 \IdrisKeyword{import}\KatlaSpace{}\IdrisModule{Language.JSON}\KatlaNewline{}
 \KatlaNewline{}


### PR DESCRIPTION
Instead of the current UseVerbatim environment. This allows us to center code blocks.

This doesn't seem to interfere with inline blocks. Perhaps it prevents word-wrap?