### PR TITLE
Attempt to fix deprecated cache action

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
       # This caching step allows us to save a lot of building time by only
       # self-hosting Idris2 from boostrap if absolutely necessary
       - name: Cache Idris2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-idris2
         with:
           path: |


### PR DESCRIPTION
See:

+ https://github.com/actions/cache/discussions/1510
+ https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down