### PR TITLE
[ new ] basic typst support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Ohad Kammar
 Guillaume Allais
 Jan de Muijnck-Hughes
 Robert Wright
+Stefan Höck

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ src: src/**/*.idr
 build/exec/katla: src 
 	idris2 --build katla.ipkg
 
+build/exec/katla-typst: src 
+	idris2 --build katla-typst.ipkg
+
 build/exec/katla-pandoc: .PHONY
 	idris2 --build katla-pandoc.ipkg
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ $ grep usepackage src/Katla/LaTeX.idr
 Active examples of using Katla can be found in the main repository of Idris2:  
 https://github.com/idris-lang/Idris2/blob/main/.github/scripts/katla.sh
 
+## Using `katla-typst`
+
+To generate semantically highlighted typst documents from literate `.typ`
+files, build and invoke `katla-typst`:
+
+```console
+$ katla-typst path/to/src/Foo.typ path/to/ttm/Foo.ttm > KFoo.typ
+```
+
+In order to use the output of the above command, you also need to
+append the output of `katla-typst preamble` to your template file:
+
+```console
+$ katla-typst preamble >> my_template.typ
+```
+
 # Demo
 See [example tests](./tests/examples).
 

--- a/katla-typst.ipkg
+++ b/katla-typst.ipkg
@@ -1,0 +1,10 @@
+package katla-typst
+
+authors = "Stefan Höck"
+
+depends = idris2, contrib, collie, idrall
+
+main = Katla.Typst.Main
+
+executable = katla-typst
+sourcedir = "src"

--- a/katla.ipkg
+++ b/katla.ipkg
@@ -20,6 +20,7 @@ modules
   , Katla.Engine
   , Katla.HTML
   , Katla.LaTeX
+  , Katla.Typst
   , Katla.Literate
   , Katla.Markdown
 

--- a/src/Katla/CLI.idr
+++ b/src/Katla/CLI.idr
@@ -10,6 +10,7 @@ import Katla.Engine
 %default covering
 %hide Collie.Modifiers.infix.(::=)
 
+export
 failWithUsage : {nm : _} -> Command nm -> IO ()
 failWithUsage cmd
   = do putStrLn cmd.usage

--- a/src/Katla/Config.idr
+++ b/src/Katla/Config.idr
@@ -167,15 +167,63 @@ defaultLatexConfig = MkConfig
     , colour = "black"
     }
   }
+
+export
+defaultTypstConfig : Config
+defaultTypstConfig = MkConfig
+  { font = #"Liberation Mono"#
+  , space = #" "#
+  , datacons = MkCategory
+    { style  = #", "normal", "medium""#
+    , colour = "rgb(\"#ff6a6a\")"
+    }
+  , typecons = MkCategory
+    { style  = #", "normal", "medium""#
+    , colour = "rgb(\"#009acd\")"
+    }
+  , bound = MkCategory
+    { style  = #", "normal", "medium""#
+    , colour = "rgb(\"#9a32cd\")"
+    }
+  , function = MkCategory
+    { style  = #", "normal", "medium""#
+    , colour = "rgb(\"#458b00\")"
+    }
+  , keyword = MkCategory
+    { style  = #", "normal", "bold""#
+    , colour = "color.black"
+    }
+  , comment = MkCategory
+    { style  = #", "italic", "medium""#
+    , colour = "rgb(\"#cdcdc1\")"
+    }
+  , hole = MkCategory
+    { style  = #", "normal", "bold""#
+    , colour = "color.yellow"
+    }
+  , namespce = MkCategory
+    { style = #", "italic", "medium""#
+    , colour = "color.black"
+    }
+  , postulte = MkCategory
+    { style = #", "normal", "bold""#
+    , colour = "rgb(\"#9a32cd\")"
+    }
+  , aModule  = MkCategory
+    { style = #", "italic", "medium""#
+    , colour = "color.black"
+    }
+  }
 %runElab (deriveFromDhall Record `{ Category })
 %runElab (deriveFromDhall Record `{ Config })
 
 public export
-data Backend = LaTeX | HTML | Markdown | Literate
+data Backend = LaTeX | Typst | HTML | Markdown | Literate
 
 export
 defaultConfig : Backend -> Config
 defaultConfig LaTeX = defaultLatexConfig
+defaultConfig Typst = defaultTypstConfig
 defaultConfig HTML = defaultHTMLConfig
 defaultConfig Markdown = defaultHTMLConfig
 defaultConfig Literate = defaultLatexConfig

--- a/src/Katla/Engine.idr
+++ b/src/Katla/Engine.idr
@@ -20,6 +20,7 @@ import Data.SnocList
 import Katla.Config
 import Katla.HTML
 import Katla.LaTeX
+import Katla.Typst
 import Katla.Markdown
 import Katla.Literate
 
@@ -250,6 +251,14 @@ engine : Backend
        -> Driver
        -> Position
        -> IO ()
+engine Typst cfg input output lnw meta driver pos
+  = do Right content <- fRead input
+         | Left err => do putStrLn "Error: \{show err}"
+                          exitFailure
+       let Right ts = lexLiterate styleCMark content
+         | Left err => do putStrLn "Error: \{show err}"
+                          exitFailure
+       engineLitWithDecor output lnw meta driver ts
 engine Markdown cfg input output lnw meta driver pos
   = do Right content <- fRead input
          | Left err => do putStrLn "Error: \{show err}"
@@ -338,6 +347,7 @@ data Snippet
 mkDriver : Backend -> (Config -> Driver)
 mkDriver HTML = HTML.mkDriver
 mkDriver LaTeX = LaTeX.mkDriver
+mkDriver Typst = Typst.mkDriver
 mkDriver Markdown = Markdown.mkDriver
 mkDriver Literate = Literate.mkDriver
 

--- a/src/Katla/Typst.idr
+++ b/src/Katla/Typst.idr
@@ -1,0 +1,154 @@
+||| Functions for generating highlighted typst code snippets
+module Katla.Typst
+
+import Core.Metadata
+import System.File
+
+import Collie
+import Katla.Config
+
+%hide Collie.Modifiers.infix.(::=)
+
+export
+escapeTypst : Char -> List Char
+escapeTypst '\n' = ['\\', '\n']
+escapeTypst '\r' = ['\\', '\r']
+escapeTypst '\t' = ['\\', '\t']
+escapeTypst '\\' = ['\\', '\\']
+escapeTypst '"'  = ['\\', '"']
+escapeTypst x    = [x]
+
+export
+annotate : Maybe Decoration -> String -> String
+annotate Nothing    s = "#\"\{s}\""
+annotate (Just dec) s = apply (convert dec) s
+  where
+
+    apply : String -> String -> String
+    apply f a = "#\{f}[#\"\{a}\"]"
+
+export
+typstHeader : Config -> String
+typstHeader cfg =  """
+
+#let IdrisCodeFont        = "\{cfg.font}"
+#let IdrisColourData      = \{cfg.datacons.colour}
+#let IdrisColourType      = \{cfg.typecons.colour}
+#let IdrisColourBound     = \{cfg.bound.colour}
+#let IdrisColourFunction  = \{cfg.function.colour}
+#let IdrisColourKeyword   = \{cfg.keyword.colour}
+#let IdrisColourImplicit  = \{cfg.bound.colour}
+#let IdrisColourComment   = \{cfg.comment.colour}
+#let IdrisColourHole      = \{cfg.hole.colour}
+#let IdrisColourNamespace = \{cfg.namespce.colour}
+#let IdrisColourPostulate = \{cfg.postulte.colour}
+#let IdrisColourModule    = \{cfg.aModule.colour}
+
+#let IdrisHighlight(col, styl, wei, cont) = {
+  set text(fill: col, style: styl, weight: wei)
+  cont
+}
+
+#let IdrisHole(cont) = {
+  set text(fill: IdrisColourHole\{cfg.hole.style})
+  cont
+}
+
+#let IdrisCode(cont) = {
+  set text(font: IdrisCodeFont, size: 0.8em)
+  cont
+}
+
+#let IdrisData(txt)      = IdrisHighlight(IdrisColourData\{cfg.datacons.style},txt)
+#let IdrisType(txt)      = IdrisHighlight(IdrisColourType\{cfg.typecons.style},txt)
+#let IdrisBound(txt)     = IdrisHighlight(IdrisColourBound\{cfg.bound.style},txt)
+#let IdrisFunction(txt)  = IdrisHighlight(IdrisColourFunction\{cfg.function.style},txt)
+#let IdrisKeyword(txt)   = IdrisHighlight(IdrisColourKeyword\{cfg.keyword.style},txt)
+#let IdrisImplicit(txt)  = IdrisHighlight(IdrisColourImplicit\{cfg.bound.style},txt)
+#let IdrisComment(txt)   = IdrisHighlight(IdrisColourComment\{cfg.comment.style},txt)
+#let IdrisNamespace(txt) = IdrisHighlight(IdrisColourNamespace\{cfg.namespce.style},txt)
+#let IdrisPostulate(txt) = IdrisHighlight(IdrisColourPostulate\{cfg.postulte.style},txt)
+#let IdrisModule(txt)    = IdrisHighlight(IdrisColourModule\{cfg.aModule.style},txt)
+"""
+
+
+export
+standalonePre : Config -> String
+standalonePre config = ""
+
+export
+makeMacroPre : String -> String
+makeMacroPre name = """
+#IdrisCode[
+"""
+
+export
+makeMacroPost : String
+makeMacroPost = """
+]
+"""
+
+export
+makeInlineMacroPre : String -> String
+makeInlineMacroPre name = ""
+
+export
+makeInlineMacroPost : String
+makeInlineMacroPost = ""
+
+export
+mkDriver : Config -> Driver
+mkDriver config = MkDriver
+  (\_, _ => "", " \\ ")
+  escapeTypst
+  annotate
+  (standalonePre config, "")
+  (makeInlineMacroPre, makeInlineMacroPost)
+  (makeMacroPre, makeMacroPost)
+
+preambleExec : (moutput : Maybe String) -> (configFile : Maybe String) -> IO ()
+preambleExec moutput configFile = do
+  Right file <- maybe (pure $ Right stdout) (flip openFile WriteTruncate) moutput
+  | Left err => putStrLn """
+              Error while opening preamble file \{maybe "stdout" id moutput}:
+              \{show err}
+              """
+  config <- getConfiguration Typst configFile
+  Right () <- fPutStr file $ typstHeader config
+  | Left err => putStrLn """
+      Error while writing preamble file \{fromMaybe "stdout" moutput}:
+      \{show err}
+      """
+  closeFile file
+
+public export
+preambleCommand : Command "preamble"
+preambleCommand = MkCommand
+  { description = "Generate Typst preamble to be used in `template.typ`"
+  , subcommands = []
+  , modifiers =
+    [ "--config" ::= option """
+        Preamble configuration file in Dhall format.
+        Use `init` to generate the defaults config file.
+        """
+        filePath
+    ]
+  , arguments = filePath
+  }
+
+export
+preamble : (ParsedCommand _ Typst.preambleCommand) -> IO ()
+preamble parsed = preambleExec parsed.arguments (parsed.modifiers.project "--config")
+
+public export
+initTypstCommand : Command "init"
+initTypstCommand = MkCommand
+  { description = "Generate preamble configuration file"
+  , subcommands = []
+  , modifiers = []
+  , arguments = filePath
+  }
+
+export
+init : (ParsedCommand _ Typst.initTypstCommand) -> IO ()
+init parsed = initExec Typst parsed.arguments

--- a/src/Katla/Typst/Main.idr
+++ b/src/Katla/Typst/Main.idr
@@ -1,0 +1,48 @@
+module Katla.Typst.Main
+
+import public Katla.CLI
+
+import Katla.Config
+import Katla.Typst
+import Katla.Engine
+
+%default covering
+%hide Collie.Modifiers.infix.(::=)
+
+typstCmd : Command "typst"
+typstCmd = MkCommand
+  { description = "Typst backend"
+  , subcommands =
+    [ "--help"   ::= basic "Print this help text." none
+    , "preamble" ::= preambleCommand
+    , "init"     ::= initTypstCommand
+    ]
+  , modifiers   = ["--config" ::= option """
+                    Preamble configuration file in Dhall format.
+                    Use `init` to generate the defaults config file.
+                    """ filePath
+                  ]
+  , arguments = lotsOf filePath
+  }
+
+typstExec : Typst.Main.typstCmd ~~> IO ()
+typstExec =
+  [ \parsed => case parsed.arguments of
+       Just [src, md, output] =>
+         katla Typst
+               Nothing -- (rawSnippet $ parsed.modifiers.project "--snippet")
+               (parsed.modifiers.project "--config")
+               (Just src) (Just md) (Just output)
+       Just [src, md]         =>
+         katla Typst
+               Nothing -- (rawSnippet $ parsed.modifiers.project "--snippet")
+               (parsed.modifiers.project "--config")
+               (Just src) (Just md) Nothing
+       _ => failWithUsage typstCmd
+  , "--help"   ::= [ const (putStrLn typstCmd.usage) ]
+  , "preamble" ::= [Typst.preamble]
+  , "init"     ::= [Typst.init]
+  ]
+
+main : IO ()
+main = typstCmd.handleWith typstExec


### PR DESCRIPTION
This adds support for adding semantic highlighting to typst literate Idris source files.

I had issues with memory consumption during elaboration when adding this as an additional backend to katla proper. I therefore turned this into a specialized `katla-typst` executable.

In its current form, no preamble is added to the converted `.typ` files. It is assumed that the preamble is generated separately and added to a `template.typ` document (or similar), which is then imported into the `.typ` files as part of a multi-file project.